### PR TITLE
feat:[APP-17045]Add limits header to  CLWParallelPrimitives.h

### DIFF
--- a/CLW/CLWParallelPrimitives.h
+++ b/CLW/CLWParallelPrimitives.h
@@ -22,6 +22,7 @@ THE SOFTWARE.
 #ifndef __CLW__CLWParallelPrimitives__
 #define __CLW__CLWParallelPrimitives__
 
+#include <limits>
 #include "CLWContext.h"
 #include "CLWProgram.h"
 #include "CLWEvent.h"


### PR DESCRIPTION
Not having the `limits` header explicitly specified causes errors with GCC10 when using `std::numeric_limits`. This PR adds the limits header explicitly to `CLWParallelPrimitives.h`