### PR TITLE
Updates compiler option for optimization.

### DIFF
--- a/RadeonRays/CMakeLists.txt
+++ b/RadeonRays/CMakeLists.txt
@@ -217,7 +217,7 @@ endif (RR_USE_VULKAN)
 target_compile_features(RadeonRays PRIVATE cxx_std_14)
 
 if (UNIX AND NOT APPLE)
-        target_compile_options(RadeonRays PUBLIC -msse4.2 -fPIC)
+        target_compile_options(RadeonRays PUBLIC -march=native -fPIC)
         target_link_libraries(RadeonRays INTERFACE "-Wl,--no-undefined")
         
         #read version from header


### PR DESCRIPTION
See https://github.com/aurorasolar/shading-engine/pull/213 for context, as well as [this SO comment](https://stackoverflow.com/questions/45905378/tensorflow-gcc-error-unrecognized-command-line-option-copt-msse4-2/45905379#45905379).

**Tested via https://github.com/aurorasolar/computation/pull/1933 before merging.**